### PR TITLE
Add new method to be called when each patch is completed

### DIFF
--- a/wp-background-process.php
+++ b/wp-background-process.php
@@ -330,6 +330,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			if ( ! empty( $batch->data ) && ! $this->is_process_cancelled() ) {
 				$this->update( $batch->key, $batch->data );
 			} else {
+				$this->complete_patch();
 				$this->delete( $batch->key );
 			}
 		} while ( ! $this->time_exceeded() && ! $this->memory_exceeded() && ! $this->is_queue_empty() && ! $this->is_process_cancelled() );
@@ -404,6 +405,13 @@ abstract class WP_Background_Process extends WP_Async_Request {
 		}
 
 		return apply_filters( $this->identifier . '_time_exceeded', $return );
+	}
+
+	/**
+	 * Current patch is completed.
+	 */
+	protected function complete_patch(){
+		// Override this code on the instantiated process class just if needed.
 	}
 
 	/**

--- a/wp-background-process.php
+++ b/wp-background-process.php
@@ -330,7 +330,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 			if ( ! empty( $batch->data ) && ! $this->is_process_cancelled() ) {
 				$this->update( $batch->key, $batch->data );
 			} else {
-				$this->complete_patch();
+				$this->complete_batch();
 				$this->delete( $batch->key );
 			}
 		} while ( ! $this->time_exceeded() && ! $this->memory_exceeded() && ! $this->is_queue_empty() && ! $this->is_process_cancelled() );
@@ -408,9 +408,9 @@ abstract class WP_Background_Process extends WP_Async_Request {
 	}
 
 	/**
-	 * Current patch is completed.
+	 * Current batch is completed.
 	 */
-	protected function complete_patch(){
+	protected function complete_batch(){
 		// Override this code on the instantiated process class just if needed.
 	}
 


### PR DESCRIPTION
Sometimes we need to run code when one patch finishes its work, not after the queue is finished.

On this PR I created a new protected method to be overridden on the process class so it's called after each patch finishes its work.