### PR TITLE
Add current blog ID to the task identifier

### DIFF
--- a/wp-async-request.php
+++ b/wp-async-request.php
@@ -54,7 +54,7 @@ abstract class WP_Async_Request {
 	 * Initiate new async request
 	 */
 	public function __construct() {
-		$this->identifier = $this->prefix . '_' . $this->action;
+		$this->identifier = $this->prefix . '_' . $this->action . '_' . get_current_blog_id();
 
 		add_action( 'wp_ajax_' . $this->identifier, array( $this, 'maybe_handle' ) );
 		add_action( 'wp_ajax_nopriv_' . $this->identifier, array( $this, 'maybe_handle' ) );


### PR DESCRIPTION
### Description of the issue

The library is using site option to save the queue batches in the database. This is ok on single site, but not on multisite.

The issue with the current implementation on multisite is if 2 sub-sites are processing the same job, the same option name will be used for both. This leads to the issue described in https://github.com/wp-media/wp-rocket/issues/1686 & https://github.com/wp-media/wp-rocket/issues/3901

### Solution
To avoid this issue, I used the current blog ID in the job identifier. That way, each subsite will only care for the jobs related to them, and there won't be any risk of mixed-up data between sites either.